### PR TITLE
Update condition for invalid username

### DIFF
--- a/EventListener/UnauthorisedListener.php
+++ b/EventListener/UnauthorisedListener.php
@@ -75,7 +75,8 @@ class UnauthorisedListener
             $username = $this->request->get('_username');
             if ($username !== null) {
                 $user = $this->userManager->findUserByUsername($username);
-                if ($user->getConfirmationToken() !== null
+                if ($user !== null
+                    && $user->getConfirmationToken() !== null
                     && $user->isEnabled() === false
                 ) {
                     throw new AccessDeniedException(


### PR DESCRIPTION
`findUserByUsername` method can return `null`, but this case was not validated in the condition.
If `null` is returned instead of object it causes error as the condition expects valid object.